### PR TITLE
Fix CMake to be able to use c-open as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #*******************************************************************/
 
 cmake_minimum_required (VERSION 3.13)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 project (CANOPEN VERSION 0.1.0)
 
 include(CTest)


### PR DESCRIPTION
Export the required include directories for use in a toplevel build which
includes this repo as a submodule/subdir and uses it like this:

  add_subdirectory (lib/c-open)
  target_link_libraries (slave PUBLIC canopen)

Remove the weird and now unnecessary coupling between the example
slave/master and the platform cmake files.