### PR TITLE
Move SDO abort codes to public header

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -53,6 +53,52 @@ typedef struct co_client co_client_t;
 #define CO_ERR_DEVICE        (1U << 5)
 #define CO_ERR_MANUFACTURER  (1U << 6)
 
+/** Abort error codes. See CiA 301 7.2.4 */
+typedef enum co_sdo_abort
+{
+   CO_SDO_ABORT_TOGGLE                = 0x05030000, /**< Toggle bit not alternated. */
+   CO_SDO_ABORT_TIMEOUT               = 0x05040000, /**< SDO protocol timed out. */
+   CO_SDO_ABORT_UNKNOWN               = 0x05040001, /**< Client/server command specifier not valid or unknown. */
+   CO_SDO_ABORT_INVALID_BLOCK_SIZE    = 0x05040002, /**< Invalid block size (block mode only). */
+   CO_SDO_ABORT_INVALID_SEQ_NO        = 0x05040003, /**< Invalid sequence number (block mode only). */
+   CO_SDO_ABORT_CRC_ERROR             = 0x05040004, /**< CRC error (block mode only). */
+   CO_SDO_ABORT_OUT_OF_MEMORY         = 0x05040005, /**< Out of memory. */
+   CO_SDO_ABORT_ACCESS                = 0x06010000, /**< Unsupported access to an object. */
+   CO_SDO_ABORT_ACCESS_WO             = 0x06010001, /**< Attempt to read a write only object. */
+   CO_SDO_ABORT_ACCESS_RO             = 0x06010002, /**< Attempt to write a read only object. */
+   CO_SDO_ABORT_BAD_INDEX             = 0x06020000, /**< Object does not exist in the object dictionary. */
+   CO_SDO_ABORT_UNMAPPABLE            = 0x06040041, /**< Object cannot be mapped to the PDO. */
+   CO_SDO_ABORT_PDO_LENGTH            = 0x06040042, /**< The number and length of the objects to be
+                                                       mapped would exceed PDO length. */
+   CO_SDO_ABORT_PARAM_INCOMPATIBLE    = 0x06040043, /**< General parameter incompatibility reason. */
+   CO_SDO_ABORT_INTERNAL_INCOMPATIBLE = 0x06040047, /**< General internal incompatibility in the device. */
+   CO_SDO_ABORT_HW_ERROR              = 0x06060000, /**< Access failed due to a hardware error. */
+   CO_SDO_ABORT_LENGTH                = 0x06070010, /**< Data type does not match, length of service
+                                                       parameter does not match */
+   CO_SDO_ABORT_LENGTH_TOO_HIGH       = 0x06070012, /**< Data type does not match, length of service
+                                                       parameter too high */
+   CO_SDO_ABORT_LENGTH_TOO_LOW        = 0x06070013, /**< Data type does not match, length of service
+                                                       parameter too low */
+   CO_SDO_ABORT_BAD_SUBINDEX          = 0x06090011, /**< Sub-index does not exist. */
+   CO_SDO_ABORT_VALUE                 = 0x06090030, /**< Invalid value for parameter (download only). */
+   CO_SDO_ABORT_VALUE_TOO_HIGH        = 0x06090031, /**< Value of parameter written too high (download only). */
+   CO_SDO_ABORT_VALUE_TOO_LOW         = 0x06090032, /**< Value of parameter written too low (download only). */
+   CO_SDO_ABORT_MAX_LT_MIN            = 0x06090036, /**< Maximum value is less than minimum value. */
+   CO_SDO_ABORT_OUT_OF_RESOURCE       = 0x060A0023, /**< Resource not available: SDO connection */
+   CO_SDO_ABORT_GENERAL               = 0x08000000, /**< General error */
+   CO_SDO_ABORT_WRITE                 = 0x08000020, /**< Data cannot be transferred or stored to the
+                                                       application. */
+   CO_SDO_ABORT_WRITE_LOCAL_DENIED    = 0x08000021, /**< Data cannot be transferred or stored to the
+                                                       application because of local control. */
+   CO_SDO_ABORT_WRITE_STATE_DENIED    = 0x08000022, /**< Data cannot be transferred or stored to the
+                                                       application because of the present device state. */
+   CO_SDO_ABORT_BAD_OD                = 0x08000023, /**< Object dictionary dynamic generation fails or no
+                                                       object dictionary is present (e.g. object dictionary
+                                                       is generated from file and generation fails
+                                                       because of an file error). */
+   CO_SDO_ABORT_NO_DATA               = 0x08000024, /**< No data available */
+} co_sdo_abort_t;
+
 /**
  * NMT states, see CiA 301 chapter 7.3.2
  *

--- a/src/co_sdo.h
+++ b/src/co_sdo.h
@@ -54,52 +54,6 @@ extern "C"
 #define CO_SDO_INDEX(d)    (d[1] << 8 | d[2])
 #define CO_SDO_SUBINDEX(d) (d[3])
 
-/* Abort error codes */
-typedef enum co_sdo_abort
-{
-   CO_SDO_ABORT_TOGGLE                = 0x05030000, /* Toggle bit not alternated. */
-   CO_SDO_ABORT_TIMEOUT               = 0x05040000, /* SDO protocol timed out. */
-   CO_SDO_ABORT_UNKNOWN               = 0x05040001, /* Client/server command specifier not valid or unknown. */
-   CO_SDO_ABORT_INVALID_BLOCK_SIZE    = 0x05040002, /* Invalid block size (block mode only). */
-   CO_SDO_ABORT_INVALID_SEQ_NO        = 0x05040003, /* Invalid sequence number (block mode only). */
-   CO_SDO_ABORT_CRC_ERROR             = 0x05040004, /* CRC error (block mode only). */
-   CO_SDO_ABORT_OUT_OF_MEMORY         = 0x05040005, /* Out of memory. */
-   CO_SDO_ABORT_ACCESS                = 0x06010000, /* Unsupported access to an object. */
-   CO_SDO_ABORT_ACCESS_WO             = 0x06010001, /* Attempt to read a write only object. */
-   CO_SDO_ABORT_ACCESS_RO             = 0x06010002, /* Attempt to write a read only object. */
-   CO_SDO_ABORT_BAD_INDEX             = 0x06020000, /* Object does not exist in the object dictionary. */
-   CO_SDO_ABORT_UNMAPPABLE            = 0x06040041, /* Object cannot be mapped to the PDO. */
-   CO_SDO_ABORT_PDO_LENGTH            = 0x06040042, /* The number and length of the objects to be
-                                                       mapped would exceed PDO length. */
-   CO_SDO_ABORT_PARAM_INCOMPATIBLE    = 0x06040043, /* General parameter incompatibility reason. */
-   CO_SDO_ABORT_INTERNAL_INCOMPATIBLE = 0x06040047, /* General internal incompatibility in the device. */
-   CO_SDO_ABORT_HW_ERROR              = 0x06060000, /* Access failed due to a hardware error. */
-   CO_SDO_ABORT_LENGTH                = 0x06070010, /* Data type does not match, length of service
-                                                       parameter does not match */
-   CO_SDO_ABORT_LENGTH_TOO_HIGH       = 0x06070012, /* Data type does not match, length of service
-                                                       parameter too high */
-   CO_SDO_ABORT_LENGTH_TOO_LOW        = 0x06070013, /* Data type does not match, length of service
-                                                       parameter too low */
-   CO_SDO_ABORT_BAD_SUBINDEX          = 0x06090011, /* Sub-index does not exist. */
-   CO_SDO_ABORT_VALUE                 = 0x06090030, /* Invalid value for parameter (download only). */
-   CO_SDO_ABORT_VALUE_TOO_HIGH        = 0x06090031, /* Value of parameter written too high (download only). */
-   CO_SDO_ABORT_VALUE_TOO_LOW         = 0x06090032, /* Value of parameter written too low (download only). */
-   CO_SDO_ABORT_MAX_LT_MIN            = 0x06090036, /* Maximum value is less than minimum value. */
-   CO_SDO_ABORT_OUT_OF_RESOURCE       = 0x060A0023, /* Resource not available: SDO connection */
-   CO_SDO_ABORT_GENERAL               = 0x08000000, /* General error */
-   CO_SDO_ABORT_WRITE                 = 0x08000020, /* Data cannot be transferred or stored to the
-                                                       application. */
-   CO_SDO_ABORT_WRITE_LOCAL_DENIED    = 0x08000021, /* Data cannot be transferred or stored to the
-                                                       application because of local control. */
-   CO_SDO_ABORT_WRITE_STATE_DENIED    = 0x08000022, /* Data cannot be transferred or stored to the
-                                                       application because of the present device state. */
-   CO_SDO_ABORT_BAD_OD                = 0x08000023, /* Object dictionary dynamic generation fails or no
-                                                       object dictionary is present (e.g. object dictionary
-                                                       is generated from file and generation fails
-                                                       because of an file error). */
-   CO_SDO_ABORT_NO_DATA               = 0x08000024, /* No data available */
-} co_sdo_abort_t;
-
 /**
  * Send SDO abort message
  *


### PR DESCRIPTION
Make SDO abort codes public as they are needed to implement an SDO
access function.