### PR TITLE
Allow COB-ID 0x180 to support CiA 417 profile

### DIFF
--- a/src/co_util.h
+++ b/src/co_util.h
@@ -43,7 +43,7 @@ static inline bool co_validate_cob_id (uint32_t id)
       return false;
    else if (id >= 0x001 && id <= 0x07F)
       return false;
-   else if (id >= 0x101 && id <= 0x180)
+   else if (id >= 0x101 && id < 0x180) /* Allow 0x180 to support CiA 417 */
       return false;
    else if (id >= 0x581 && id <= 0x5FF)
       return false;


### PR DESCRIPTION
For some reason, CiA 417:3 specifies a COB-ID for PDO 261 which is
restricted by CiA 301 §7.3.5 for use as COB-IDs.

Relax the check to allow 0x180 in order to support these
applications.