### PR TITLE
Accept too long PDOs

### DIFF
--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -702,9 +702,10 @@ void co_pdo_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc)
 
          if (pdo->cobid == id)
          {
-            if (CO_BYTELENGTH (pdo->bitlength) != dlc)
+            if (CO_BYTELENGTH (pdo->bitlength) > dlc)
             {
-               /* Bad PDO length */
+               /* PDO received is too short. Sending EMCY when it's too long is
+                * optional, so don't do that (data must still be consumed). */
                co_emcy_tx (net, 0x8210, 0, NULL);
             }
             else

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -119,9 +119,11 @@ void mock_co_od_reset (co_net_t * net)
 }
 
 unsigned int mock_co_emcy_tx_calls = 0;
-void mock_co_emcy_tx (co_net_t * net)
+uint16_t mock_co_emcy_tx_code = 0;
+void mock_co_emcy_tx (co_net_t * net, uint16_t code)
 {
    mock_co_emcy_tx_calls++;
+   mock_co_emcy_tx_code = code;
 }
 
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -75,7 +75,8 @@ extern unsigned int mock_co_od_reset_calls;
 void mock_co_od_reset (co_net_t * net);
 
 extern unsigned int mock_co_emcy_tx_calls;
-void mock_co_emcy_tx (co_net_t * net);
+extern uint16_t mock_co_emcy_tx_code;
+void mock_co_emcy_tx (co_net_t * net, uint16_t code);
 
 extern unsigned int cb_reset_calls;
 void cb_reset (void * arg);


### PR DESCRIPTION
If a received PDO is longer than the mapped objects, the device SHALL
consume the mapped part of the payload and MAY transmit an EMCY (CiA 301
7.5.2.36). Current code discards the data and sends an EMCY.

Only abort reception and send EMCY if the PDO length is shorter than the
mapped objects, as required. Process the frame normally and skip the EMCY
if the PDO is longer.

Fixes: rtlabs-com/c-open#21