### PR TITLE
Fix index-out-of-bounds read when validating PDO mapping

### DIFF
--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -124,6 +124,10 @@ static uint32_t co_pdo_mapping_validate (co_pdo_t * pdo, uint8_t number_of_mappi
 {
    int ix;
 
+   /* Mappings array bounds check */
+   if (number_of_mappings > MAX_PDO_ENTRIES)
+      return CO_SDO_ABORT_PDO_LENGTH;
+
    /* Check that bitlength is OK */
    pdo->bitlength = 0;
    for (ix = 0; ix < number_of_mappings; ix++)


### PR DESCRIPTION
The number_of_mappings argument to the validation function comes straight
from the 8-bit payload when writing to subindex 0 of the PDO mapping
objects and will, during the summing of the bitlengths, read outside the
mappings array if the payload is greater than MAX_PDO_ENTRIES.
