### PR TITLE
Fix PDOs sending remote frames instead of actual data

### DIFF
--- a/src/co_main.h
+++ b/src/co_main.h
@@ -35,9 +35,10 @@ extern "C" {
 
 #define CO_BYTELENGTH(bitlength) (((bitlength) + 7) / 8)
 
-#define CO_RTR_MASK BIT (30)
-#define CO_EXT_MASK BIT (29)
-#define CO_ID_MASK  0x1FFFFFFF
+#define CO_RTR_MASK   BIT (30)
+#define CO_EXT_MASK   BIT (29)
+#define CO_ID_MASK    0x1FFFFFFF
+#define CO_EXTID_MASK (CO_EXT_MASK | CO_ID_MASK)
 
 #define CO_COBID_INVALID BIT (31)
 #define CO_NODE_GET(id)  ((id)&0x7F)

--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -538,7 +538,7 @@ static void co_pdo_transmit (co_net_t * net, co_pdo_t * pdo)
    /* Transmit PDO */
    co_pdo_pack (net, pdo);
    dlc = CO_BYTELENGTH (pdo->bitlength);
-   os_channel_send (net->channel, pdo->cobid, &pdo->frame, dlc);
+   os_channel_send (net->channel, pdo->cobid & CO_EXTID_MASK, &pdo->frame, dlc);
    pdo->timestamp = now;
    pdo->queued    = false;
 }
@@ -685,7 +685,7 @@ void co_pdo_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc)
 
    if (id & CO_RTR_MASK)
    {
-      id &= ~CO_RTR_MASK;
+      id &= CO_EXTID_MASK;
       for (ix = 0; ix < MAX_TX_PDO; ix++)
       {
          co_pdo_t * pdo = &net->pdo_tx[ix];

--- a/src/co_sync.c
+++ b/src/co_sync.c
@@ -157,7 +157,7 @@ int co_sync_timer (co_net_t * net, uint32_t now)
             co_put_uint8 (msg, sync->counter);
             os_channel_send (
                net->channel,
-               sync->cobid & 0x1FFFFFF,
+               sync->cobid & CO_EXTID_MASK,
                msg,
                sizeof (msg));
 
@@ -166,7 +166,7 @@ int co_sync_timer (co_net_t * net, uint32_t now)
          }
          else
          {
-            os_channel_send (net->channel, sync->cobid & 0x1FFFFFFF, NULL, 0);
+            os_channel_send (net->channel, sync->cobid & CO_EXTID_MASK, NULL, 0);
          }
 
          /* Call user callback */


### PR DESCRIPTION
If a TPDO communication parameter has the RTR bit set, meaning remote
transmission requests are not allowed for this PDO, the PDO transmission
will send an RTR frame instead of the data when it's triggered, due to a
missing mask on the COB-ID when sending the frame.

Also audit other cases of calling os_channel_send() without masking and
as a result, replace hard-coded mask constants in SYNC sending (one of
which was incorrect!) with the appropriate macro.

Include the extended-frame bit in the mask to support 29-bit frames if
these should be configured in any COB-ID; it makes little sense to
include all 29 ID bits in the mask if the extended-frame flag is left
out.