### PR TITLE
Bus off recovery

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -294,6 +294,7 @@ typedef struct co_cfg
 {
    uint8_t node;                  /**< Initial node ID */
    int bitrate;                   /**< Initial bitrate (bits per second) */
+   uint32_t restart_ms;           /**< Bus-off recovery delay, zero to disable */
    const co_obj_t * od;           /**< Application dictionary */
    const co_default_t * defaults; /**< Dictionary default values */
    void * cb_arg;                 /**< Callback opaque argument */

--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -278,8 +278,9 @@ int co_emcy_tx (co_net_t * net, uint16_t code, uint16_t info, uint8_t msef[5])
    }
 
    /* Always trigger error behavior on the mandatory events,
-    * otherwise, follow the callback return value. */
-   if (code == 0x8130 || code == 0x8140 || error_behavior) {
+    * otherwise, follow the callback return value. The bus-off
+    * event was handled when it happened. */
+   if (code == 0x8130 || error_behavior) {
       co_trigger_error_behavior (net);
    }
 
@@ -357,6 +358,8 @@ void co_emcy_handle_can_state (co_net_t * net)
          net->cb_emcy (net, net->node, 0x8140,
                        co_emcy_error_register_get(net), NULL);
       }
+
+      co_trigger_error_behavior (net);
    }
 
    if (!net->emcy.state.bus_off && previous.bus_off)

--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -331,6 +331,11 @@ void co_emcy_handle_can_state (co_net_t * net)
    if (status != 0)
       return;
 
+   /* Attempt to go bus on again. */
+   if (net->emcy.state.bus_off) {
+      os_channel_bus_on(net->channel);
+   }
+
    /* Check for new communication errors */
 
    if (net->emcy.state.overrun && !previous.overrun)

--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -16,6 +16,7 @@
 #ifdef UNIT_TEST
 #define os_channel_send        mock_os_channel_send
 #define os_channel_get_state   mock_os_channel_get_state
+#define os_channel_bus_on      mock_os_channel_bus_on
 #define os_get_current_time_us mock_os_get_current_time_us
 #endif
 

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -423,6 +423,8 @@ co_net_t * co_init (const char * canif, const co_cfg_t * cfg)
    net->cb_emcy   = cfg->cb_emcy;
    net->cb_notify = cfg->cb_notify;
 
+   net->restart_ms = cfg->restart_ms;
+
    net->open  = cfg->open;
    net->read  = cfg->read;
    net->write = cfg->write;

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -214,6 +214,7 @@ typedef struct co_emcy
 {
    uint32_t cobid;                   /**< EMCY COB ID */
    uint32_t timestamp;               /**< Timestamp of last EMCY */
+   uint32_t bus_off_timestamp;       /**< Timestamp of bus-off event */
    uint16_t inhibit;                 /**< Inhibit time [100 us] */
    uint8_t error;                    /**< Error register */
    os_channel_state_t state;         /**< CAN state */
@@ -241,6 +242,7 @@ struct co_net
    uint32_t hb_time;            /**< Heartbeat producer time */
    uint32_t sync_timestamp;     /**< Timestamp of last SYNC */
    uint32_t sync_window;        /**< Synchronous window length */
+   uint32_t restart_ms;         /**< Delay before attempting to recover from bus-off */
    co_pdo_t pdo_tx[MAX_TX_PDO]; /**< TPDOs */
    co_pdo_t pdo_rx[MAX_RX_PDO]; /**< RPDOs */
    co_node_guard_t node_guard;  /**< Node guarding state */

--- a/test/test_emcy.cpp
+++ b/test/test_emcy.cpp
@@ -400,6 +400,21 @@ TEST_F (EmcyTest, EmcyBusOff)
    EXPECT_TRUE (CanMatch (0x81, expected[0], 8)); // Last error
 }
 
+TEST_F (EmcyTest, EmcyBusOffRecovery)
+{
+   // Set auto restart timeout
+   net.restart_ms = 100;
+
+   // Enter bus_off error state
+   mock_os_channel_get_state_state.bus_off = true;
+   co_emcy_handle_can_state (&net);
+
+   // Should attempt bus off recovery after timeout
+   mock_os_get_current_time_us_result = 101 * 1000;
+   co_emcy_handle_can_state (&net);
+   EXPECT_EQ (1u, mock_os_channel_bus_on_calls);
+}
+
 TEST_F (EmcyTest, EmcyInhibit)
 {
    net.emcy.inhibit = 10; // 10 * 100 us


### PR DESCRIPTION
A workaround for CAN drivers which doesn't take care of bus-off recovery themselves. Since there is no API to go bus on again from the application, let the stack attempt recovery after a configurable delay (like the restart-ms argument to SocketCAN drivers).

Also perform any actions that should be done at bus-off (error behavior and application notification) at the actual bus-off event, instead of when/if it recovers. For the application notification, reuse the EMCY callback with the 0x8140 code.