### PR TITLE
Pass the read/write intent to the OD store open call

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -278,6 +278,13 @@ typedef enum co_store
    CO_STORE_LAST,
 } co_store_t;
 
+/** Dictionary store open modes */
+typedef enum co_mode
+{
+   CO_MODE_READ,  /**< Open for reading */
+   CO_MODE_WRITE, /**< Open for writing */
+} co_mode_t;
+
 /** CANopen stack configuration */
 typedef struct co_cfg
 {
@@ -308,7 +315,7 @@ typedef struct co_cfg
    void (*cb_notify) (void * arg, uint16_t index, uint8_t subindex);
 
    /** Function to open dictionary store */
-   void * (*open) (co_store_t store);
+   void * (*open) (co_store_t store, co_mode_t mode);
 
    /** Function to read from dictionary store */
    int (*read) (void * arg, void * data, size_t size);

--- a/src/co_lss.c
+++ b/src/co_lss.c
@@ -266,7 +266,7 @@ static void co_lss_store_configuration (co_net_t * net, uint8_t * _msg)
       goto error1;
    }
 
-   arg = net->open (CO_STORE_LSS);
+   arg = net->open (CO_STORE_LSS, CO_MODE_WRITE);
    if (arg == NULL)
       goto error1;
 
@@ -489,7 +489,7 @@ uint8_t co_lss_get_persistent_node_id (co_net_t * net)
    if (net->open == NULL || net->read == NULL || net->close == NULL)
       goto error1;
 
-   arg = net->open (CO_STORE_LSS);
+   arg = net->open (CO_STORE_LSS, CO_MODE_READ);
    if (arg == NULL)
       goto error1;
 
@@ -521,7 +521,7 @@ int co_lss_get_persistent_bitrate (co_net_t * net)
    if (net->open == NULL || net->read == NULL || net->close == NULL)
       goto error1;
 
-   arg = net->open (CO_STORE_LSS);
+   arg = net->open (CO_STORE_LSS, CO_MODE_READ);
    if (arg == NULL)
       goto error1;
 

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -278,7 +278,7 @@ struct co_net
    void (*cb_notify) (void * arg, uint16_t index, uint8_t subindex);
 
    /** Function to open dictionary store */
-   void * (*open) (co_store_t store);
+   void * (*open) (co_store_t store, co_mode_t mode);
 
    /** Function to read from dictionary store */
    int (*read) (void * arg, void * data, size_t size);

--- a/src/co_od.c
+++ b/src/co_od.c
@@ -359,7 +359,7 @@ uint32_t co_od_load (co_net_t * net, co_store_t store)
    if (net->open == NULL || net->read == NULL || net->close == NULL)
       return CO_SDO_ABORT_GENERAL;
 
-   arg = net->open (store);
+   arg = net->open (store, CO_MODE_READ);
    if (arg == NULL)
       return CO_SDO_ABORT_GENERAL;
 
@@ -457,7 +457,7 @@ uint32_t co_od_store (co_net_t * net, co_store_t store, uint16_t min, uint16_t m
    if (net->open == NULL || net->write == NULL || net->close == NULL)
       return CO_SDO_ABORT_HW_ERROR;
 
-   arg = net->open (store);
+   arg = net->open (store, CO_MODE_WRITE);
    if (arg == NULL)
       return CO_SDO_ABORT_HW_ERROR;
 
@@ -555,7 +555,7 @@ uint32_t co_od_restore (co_net_t * net, co_store_t store)
    if (net->open == NULL || net->write == NULL || net->close == NULL)
       return CO_SDO_ABORT_HW_ERROR;
 
-   arg = net->open (store);
+   arg = net->open (store, CO_MODE_WRITE);
    if (arg == NULL)
       return CO_SDO_ABORT_HW_ERROR;
 

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -187,7 +187,7 @@ void store_init (void)
 }
 
 unsigned int store_open_calls;
-void * store_open (co_store_t store)
+void * store_open (co_store_t store, co_mode_t mode)
 {
    store_open_calls++;
    _fd.p = the_store;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -108,7 +108,7 @@ void cb_notify (void * arg, uint16_t index, uint8_t subindex);
 
 void store_init (void);
 extern unsigned int store_open_calls;
-void * store_open (co_store_t store);
+void * store_open (co_store_t store, co_mode_t mode);
 int store_read (void * arg, void * data, size_t size);
 int store_write (void * arg, const void * data, size_t size);
 int store_close (void * arg);

--- a/util/slave/slave.c
+++ b/util/slave/slave.c
@@ -158,7 +158,7 @@ static struct fd
    uint8_t * p;
 } fd;
 
-static void * store_open (co_store_t store)
+static void * store_open (co_store_t store, co_mode_t mode)
 {
    if (store >= CO_STORE_LAST)
       return NULL;


### PR DESCRIPTION
For a file-based storage backend, the implementation needs to be
unnecessarily complicated because it's unknown in the open() callback
whether the stack is going to read or write the file.

The only standard stdio file modes that supports both reading and writing
are "r+", "w+" and "a+". Of these, "w+" always truncates the file, deleting
the parameters when the stack wants to read them; "a+" only allows
appending, so existing stored parameters will not get updated. Only "r+"
technically works, but leaves garbage at the end of the file when writing
if the new data is shorter than the current file, so if it works or not
depends on the data format the stack uses internally.

Pass a new argument to the open() callback to let the implementation know
what the stack is going to do with the file.

The most trivial implementation could now be something like this:

``` c
static void *store_open(co_store_t store, co_mode_t mode)
{
	static const char *filename[CO_STORE_LAST] = {
		[CO_STORE_COMM] = "od_comm",
		[CO_STORE_APP] =  "od_app",
		[CO_STORE_MFG] = "od_mfg",
		[CO_STORE_LSS] = "od_lss",
	};

	return fopen(filename[store], mode == CO_MODE_WRITE ? "wb" : "rb");
}

static int store_read(void *arg, void *data, size_t size)
{
	return fread(data, 1, size, arg) == size ? 0 : -1;
}

static int store_write(void *arg, const void *data, size_t size)
{
	return fwrite(data, 1, size, arg) == size ? 0 : -1;
}

static int store_close(void *arg)
{
	return fclose(arg) == 0 ? 0 : -1;
}
```

Signed-off-by: Andreas Fritiofson <andreas.fritiofson@unjo.com>
Change-Id: I3c1c6e3fa62c17cf672243bddd037e4ba42b4290