### PR TITLE
Only send PDOs in NMT Operational

### DIFF
--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -581,6 +581,9 @@ void co_pdo_trigger (co_net_t * net)
 {
    unsigned int ix;
 
+   if (net->state != STATE_OP)
+      return;
+
    /* Transmit event-driven TPDOs, queue acyclic TPDOs */
    for (ix = 0; ix < MAX_TX_PDO; ix++)
    {
@@ -606,6 +609,9 @@ void co_pdo_trigger_with_obj (co_net_t * net, uint16_t index, uint8_t subindex)
    uint8_t n;
    const co_obj_t * obj;
    const co_entry_t * entry;
+
+   if (net->state != STATE_OP)
+      return;
 
    /* Find mapped object */
    obj = co_obj_find (net, index);

--- a/test/test_pdo.cpp
+++ b/test/test_pdo.cpp
@@ -730,10 +730,18 @@ TEST_F (PdoTest, TxAcyclic)
 
 TEST_F (PdoTest, TriggerWithObj)
 {
-   net.state = STATE_OP;
+   net.state = STATE_PREOP;
 
    net.pdo_tx[0].transmission_type = 0xFF;
    net.pdo_tx[0].inhibit_time      = 0;
+
+   // Should not trigger PDO, bad state
+   mock_co_obj_find_result   = find_obj (0x6000);
+   mock_co_entry_find_result = find_entry (mock_co_obj_find_result, 0);
+   co_pdo_trigger_with_obj (&net, 0x6000, 0);
+   EXPECT_EQ (0x0u, mock_os_channel_send_calls);
+
+   net.state = STATE_OP;
 
    // Should trigger PDO
    mock_co_obj_find_result   = find_obj (0x6000);


### PR DESCRIPTION
Don't allow transmitting any PDOs in other NMT states, even if the
application triggers them.

Fixes #40