### PR TITLE
Fix SDO time-out on large segmented transfers

### DIFF
--- a/src/co_sdo_client.c
+++ b/src/co_sdo_client.c
@@ -325,7 +325,12 @@ int co_sdo_client_timer (co_net_t * net, uint32_t now)
    {
       if (co_is_expired (now, job->timestamp, 1000 * SDO_TIMEOUT))
       {
-         co_sdo_abort (net, 0x580 + net->node, 0, 0, CO_SDO_ABORT_TIMEOUT);
+         co_sdo_abort (
+            net,
+            0x580 + net->node,
+            job->sdo.index,
+            job->sdo.subindex,
+            CO_SDO_ABORT_TIMEOUT);
 
          job->result = CO_STATUS_ERROR;
          co_sdo_done (net);


### PR DESCRIPTION
Any sufficiently large SDO transfer will time-out, because the time is
counted from the start of the transfer. Restart the timeout as long as
progress is made, for each transferred segment.

Also fill in the index and sub-index of the object in the abort frame
if the transfer times out locally, as per CiA 301.

Additionally, fix a flaw in the SegmentedTimeout test which used
synthetic timestamps but did not mock the system time, possibly causing
sporadic failure (or pass) if run at the wrong time.

Signed-off-by: Andreas Fritiofson <andreas.fritiofson@unjo.com>
Change-Id: Ic527f80cca1c3f72e26bebb0acd6d3b06800d546