### PR TITLE
Synchronize PDO triggering with the c-open main thread

### DIFF
--- a/src/co_main.c
+++ b/src/co_main.c
@@ -223,8 +223,11 @@ int co_pdo_event (co_client_t * client)
    job->client   = client;
    job->callback = NULL;
    job->type     = CO_JOB_PDO_EVENT;
+   job->callback = co_job_callback;
 
    os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);
+   os_sem_wait (client->sem, OS_WAIT_FOREVER);
+
    return 0;
 }
 
@@ -238,8 +241,11 @@ int co_pdo_obj_event (co_client_t * client, uint16_t index, uint8_t subindex)
    job->type         = CO_JOB_PDO_OBJ_EVENT;
    job->pdo.index    = index;
    job->pdo.subindex = subindex;
+   job->callback     = co_job_callback;
 
    os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);
+   os_sem_wait (client->sem, OS_WAIT_FOREVER);
+
    return 0;
 }
 

--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -825,6 +825,10 @@ void co_pdo_job (co_net_t * net, co_job_t * job)
    default:
       CC_ASSERT (0);
    }
+
+   job->result = 0;
+   if (job->callback)
+      job->callback (job);
 }
 
 int co_pdo_init (co_net_t * net)


### PR DESCRIPTION
If a call to trigger a PDO event is done followed by a second job,
there's no guarantee that the main thread will have a chance to run
and process the PDO job to completion before the common job
description struct is overwritten by the next request.

Use the semaphore via the completion callback as for all other jobs.
