### PR TITLE
Only trigger the Error behaviour on the mandatory events

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -26,6 +26,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "co_export.h"
@@ -303,8 +304,8 @@ typedef struct co_cfg
    /** SYNC callback */
    void (*cb_sync) (void * arg);
 
-   /** EMCY callback */
-   void (*cb_emcy) (
+   /** EMCY callback, return true to enable error behavior */
+   bool (*cb_emcy) (
       void * arg,
       uint8_t node,
       uint16_t code,
@@ -480,7 +481,7 @@ CO_EXPORT int co_sdo_write (
  * Calling this function adds an error to the error history object
  * (1003h). It also signals an error to the NMT state-machine which
  * may change state according to the setting of the error behavior
- * object (1029h).
+ * object (1029h) and the return value of the EMCY callback.
  *
  * The application will be notified via the EMCY callback. The node id
  * will be the active node id for this node.

--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -257,6 +257,10 @@ int co_emcy_tx (co_net_t * net, uint16_t code, uint16_t info, uint8_t msef[5])
       net->cb_emcy (net->cb_arg, net->node, code, reg, msef);
    }
 
+   if (code != 0x8140 && code != 0x8130) {
+      return 0;
+   }
+
    /* Transition state according to error behavior setting */
    switch (net->error_behavior)
    {

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -267,7 +267,7 @@ struct co_net
    void (*cb_sync) (void * arg);
 
    /** EMCY callback */
-   void (*cb_emcy) (
+   bool (*cb_emcy) (
       void * arg,
       uint8_t node,
       uint16_t code,

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -149,7 +149,8 @@ uint8_t cb_emcy_node;
 uint16_t cb_emcy_code;
 uint8_t cb_emcy_reg;
 uint8_t cb_emcy_msef[5];
-void cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5])
+bool cb_emcy_result;
+bool cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5])
 {
    cb_emcy_calls++;
    cb_emcy_node = node;
@@ -157,6 +158,7 @@ void cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef
    cb_emcy_reg  = reg;
    if (msef != NULL)
       memcpy (cb_emcy_msef, msef, sizeof (cb_emcy_msef));
+   return cb_emcy_result;
 }
 
 unsigned int cb_sync_calls;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -96,7 +96,8 @@ extern uint8_t cb_emcy_node;
 extern uint16_t cb_emcy_code;
 extern uint8_t cb_emcy_reg;
 extern uint8_t cb_emcy_msef[5];
-void cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5]);
+extern bool cb_emcy_result;
+bool cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5]);
 
 extern unsigned int cb_sync_calls;
 void cb_sync (void * arg);

--- a/test/test_emcy.cpp
+++ b/test/test_emcy.cpp
@@ -207,26 +207,51 @@ TEST_F (EmcyTest, NMTErrorBehavior)
    EXPECT_EQ (0u, result);
    EXPECT_EQ (0u, value);
 
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_INIT, net.state);
 
-   net.state = STATE_LAST;
-   co_emcy_tx (&net, 1, 0x1234, msef);
-   EXPECT_EQ (STATE_LAST, net.state);
-
    net.state = STATE_OFF;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_OFF, net.state);
 
    net.state = STATE_STOP;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_STOP, net.state);
 
    net.state = STATE_OP;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_PREOP, net.state);
 
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_PREOP, net.state);
+
+   net.state = STATE_OP;
    co_emcy_tx (&net, 1, 0x1234, msef);
+   EXPECT_EQ (STATE_OP, net.state);
+
+   value  = 1;
+   result = co_od1029_fn (&net, OD_EVENT_WRITE, obj1029, NULL, 1, &value);
+   EXPECT_EQ (0u, result);
+   EXPECT_EQ (1, net.error_behavior);
+
+   net.state = STATE_INIT;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_INIT, net.state);
+
+   net.state = STATE_OFF;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_OFF, net.state);
+
+   net.state = STATE_STOP;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_STOP, net.state);
+
+   net.state = STATE_OP;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_OP, net.state);
+
+   net.state = STATE_PREOP;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_PREOP, net.state);
 
    value  = 2;
@@ -235,27 +260,31 @@ TEST_F (EmcyTest, NMTErrorBehavior)
    EXPECT_EQ (2, net.error_behavior);
 
    net.state = STATE_INIT;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_INIT, net.state);
 
    net.state = STATE_OFF;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_OFF, net.state);
 
    net.state = STATE_STOP;
-   co_emcy_tx (&net, 1, 0x1234, msef);
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_STOP, net.state);
+
+   net.state = STATE_OP;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_STOP, net.state);
+
+   net.state = STATE_PREOP;
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
+   EXPECT_EQ (STATE_STOP, net.state);
+
+   co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (STATE_STOP, net.state);
 
    net.state = STATE_OP;
    co_emcy_tx (&net, 1, 0x1234, msef);
-   EXPECT_EQ (STATE_STOP, net.state);
-
-   net.state = STATE_PREOP;
-   co_emcy_tx (&net, 1, 0x1234, msef);
-   EXPECT_EQ (STATE_STOP, net.state);
-
-   co_emcy_tx (&net, 1, 0x1234, msef);
-   EXPECT_EQ (STATE_STOP, net.state);
+   EXPECT_EQ (STATE_OP, net.state);
 }
 
 TEST_F (EmcyTest, EmcyOverrun)

--- a/test/test_emcy.cpp
+++ b/test/test_emcy.cpp
@@ -26,6 +26,7 @@ class EmcyTest : public TestBase
    {
       TestBase::SetUp();
       net.emcy.cobid = 0x81;
+      cb_emcy_result = false;
    }
 
    uint8_t msef[5] = {5, 4, 3, 2, 1};
@@ -283,8 +284,15 @@ TEST_F (EmcyTest, NMTErrorBehavior)
    EXPECT_EQ (STATE_STOP, net.state);
 
    net.state = STATE_OP;
+   cb_emcy_result = false;
    co_emcy_tx (&net, 1, 0x1234, msef);
    EXPECT_EQ (STATE_OP, net.state);
+
+   net.state = STATE_OP;
+   cb_emcy_result = true;
+   co_emcy_tx (&net, 1, 0x1234, msef);
+   EXPECT_EQ (STATE_STOP, net.state);
+
 }
 
 TEST_F (EmcyTest, EmcyOverrun)


### PR DESCRIPTION
The automatic NMT transition to Pre-operational, or any other action
that has been configured in 1029h, is only required to happen on Bus-
off or Life guarding/Heartbeat time-out. Currently, all EMCYs that are
sent do trigger the error behaviour, even if the error is not a
"serious CANopen device failure". It even reverts back to pre-operational
when an error is cleared and EMCY 0x0000 is sent.

Turn off the error behaviour except for EMCY codes 0x8130 and 0x8140
which correspond to the mandatory events (although the Bus-off EMCY
actually means *recovery* from Bus-off, so the Error behavior will
happen much later than was probably intended).

Ref: #39