### PR TITLE
Pass the network handle to callback functions instead of cb_arg

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -383,6 +383,18 @@ CO_EXPORT co_client_t * co_client_init (co_net_t * net);
 CO_EXPORT uint8_t co_node_next (co_client_t * client, uint8_t node);
 
 /**
+ * Get active node ID.
+ *
+ * This function returns this node's active node ID, i.e. the
+ * default ID set to co_init(), unless overridden via LSS.
+ *
+ * @param net           network handle
+ *
+ * @return the active node id
+ */
+CO_EXPORT uint8_t co_node_id_get (co_net_t * net);
+
+/**
  * Get callback argument.
  *
  * This function returns the callback opaque argument specified to

--- a/include/co_api.h
+++ b/include/co_api.h
@@ -296,24 +296,24 @@ typedef struct co_cfg
    void * cb_arg;                 /**< Callback opaque argument */
 
    /** Reset callback */
-   void (*cb_reset) (void * arg);
+   void (*cb_reset) (co_net_t * net);
 
    /** NMT callback */
-   void (*cb_nmt) (void * arg, co_state_t state);
+   void (*cb_nmt) (co_net_t * net, co_state_t state);
 
    /** SYNC callback */
-   void (*cb_sync) (void * arg);
+   void (*cb_sync) (co_net_t * net);
 
    /** EMCY callback, return true to enable error behavior */
    bool (*cb_emcy) (
-      void * arg,
+      co_net_t * net,
       uint8_t node,
       uint16_t code,
       uint8_t reg,
       uint8_t msef[5]);
 
    /** Notify callback */
-   void (*cb_notify) (void * arg, uint16_t index, uint8_t subindex);
+   void (*cb_notify) (co_net_t * net, uint16_t index, uint8_t subindex);
 
    /** Function to open dictionary store */
    void * (*open) (co_store_t store, co_mode_t mode);
@@ -381,6 +381,19 @@ CO_EXPORT co_client_t * co_client_init (co_net_t * net);
  * @return next active node
  */
 CO_EXPORT uint8_t co_node_next (co_client_t * client, uint8_t node);
+
+/**
+ * Get callback argument.
+ *
+ * This function returns the callback opaque argument specified to
+ * co_init(), for example to reach application specific context from
+ * object access functions and other callbacks.
+ *
+ * @param net           network handle
+ *
+ * @return the opaque callback argument
+ */
+CO_EXPORT void * co_cb_arg_get (co_net_t * net);
 
 /**
  * Send NMT command.

--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -274,7 +274,7 @@ int co_emcy_tx (co_net_t * net, uint16_t code, uint16_t info, uint8_t msef[5])
     * called at the actual bus-off event. */
    if (net->cb_emcy && code != 0x8140)
    {
-      error_behavior = net->cb_emcy (net->cb_arg, net->node, code, reg, msef);
+      error_behavior = net->cb_emcy (net, net->node, code, reg, msef);
    }
 
    /* Always trigger error behavior on the mandatory events,
@@ -313,7 +313,7 @@ int co_emcy_rx (co_net_t * net, uint32_t id, uint8_t * msg, size_t dlc)
       /* Call user callback */
       if (net->cb_emcy)
       {
-         net->cb_emcy (net->cb_arg, CO_NODE_GET (id), code, reg, msef);
+         net->cb_emcy (net, CO_NODE_GET (id), code, reg, msef);
       }
    }
 
@@ -354,7 +354,7 @@ void co_emcy_handle_can_state (co_net_t * net)
       /* Call user callback directly, cannot call co_emcy_tx() now */
       if (net->cb_emcy)
       {
-         net->cb_emcy (net->cb_arg, net->node, 0x8140,
+         net->cb_emcy (net, net->node, 0x8140,
                        co_emcy_error_register_get(net), NULL);
       }
    }

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -215,6 +215,11 @@ uint8_t co_node_next (co_client_t * client, uint8_t node)
    return co_bitmap_next (net->nodes, node);
 }
 
+void * co_cb_arg_get (co_net_t * net)
+{
+   return net->cb_arg;
+}
+
 int co_pdo_event (co_client_t * client)
 {
    co_net_t * net = client->net;

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -215,6 +215,11 @@ uint8_t co_node_next (co_client_t * client, uint8_t node)
    return co_bitmap_next (net->nodes, node);
 }
 
+uint8_t co_node_id_get (co_net_t * net)
+{
+   return net->node;
+}
+
 void * co_cb_arg_get (co_net_t * net)
 {
    return net->cb_arg;

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -258,24 +258,24 @@ struct co_net
    uint32_t mbox_overrun; /**< Mailbox overruns (for debugging) */
 
    /** Reset callback */
-   void (*cb_reset) (void * arg);
+   void (*cb_reset) (co_net_t * net);
 
    /** NMT callback */
-   void (*cb_nmt) (void * arg, co_state_t state);
+   void (*cb_nmt) (co_net_t * net, co_state_t state);
 
    /** SYNC callback */
-   void (*cb_sync) (void * arg);
+   void (*cb_sync) (co_net_t * net);
 
    /** EMCY callback */
    bool (*cb_emcy) (
-      void * arg,
+      co_net_t * net,
       uint8_t node,
       uint16_t code,
       uint8_t reg,
       uint8_t msef[5]);
 
    /** Notify callback */
-   void (*cb_notify) (void * arg, uint16_t index, uint8_t subindex);
+   void (*cb_notify) (co_net_t * net, uint16_t index, uint8_t subindex);
 
    /** Function to open dictionary store */
    void * (*open) (co_store_t store, co_mode_t mode);

--- a/src/co_nmt.c
+++ b/src/co_nmt.c
@@ -49,7 +49,7 @@ static co_fsm_event_t co_nmt_reset (co_net_t * net, co_fsm_event_t event)
    {
       if (net->cb_reset)
       {
-         net->cb_reset (net->cb_arg);
+         net->cb_reset (net);
       }
 
       /* Reset application and manufacturer-specific area*/
@@ -153,7 +153,7 @@ void co_nmt_event (co_net_t * net, co_fsm_event_t event)
       {
          if (net->cb_nmt)
          {
-            net->cb_nmt (net->cb_arg, net->state);
+            net->cb_nmt (net, net->state);
          }
       }
 
@@ -163,7 +163,7 @@ void co_nmt_event (co_net_t * net, co_fsm_event_t event)
 void co_nmt_init (co_net_t * net)
 {
    unsigned int i, j;
-   void (*cb_reset) (void * arg);
+   void (*cb_reset) (co_net_t * net);
 
    /* Set FSM defaults */
    for (i = 0; i < STATE_LAST; i++)

--- a/src/co_od.c
+++ b/src/co_od.c
@@ -45,7 +45,7 @@ static void co_od_notify (
    if (entry->flags & OD_NOTIFY)
    {
       if (net->cb_notify)
-         net->cb_notify (net->cb_arg, obj->index, subindex);
+         net->cb_notify (net, obj->index, subindex);
    }
 }
 

--- a/src/co_pdo.c
+++ b/src/co_pdo.c
@@ -726,7 +726,7 @@ int co_pdo_sync (co_net_t * net, uint8_t * msg, size_t dlc)
    /* Call user callback */
    if (net->cb_sync)
    {
-      net->cb_sync (net->cb_arg);
+      net->cb_sync (net);
    }
 
    return 0;

--- a/src/co_sync.c
+++ b/src/co_sync.c
@@ -175,7 +175,7 @@ int co_sync_timer (co_net_t * net, uint32_t now)
          /* Call user callback */
          if (net->cb_sync)
          {
-            net->cb_sync (net->cb_arg);
+            net->cb_sync (net);
          }
       }
    }

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -133,13 +133,13 @@ void mock_co_emcy_tx (co_net_t * net, uint16_t code)
 }
 
 unsigned int cb_reset_calls;
-void cb_reset (void * arg)
+void cb_reset (co_net_t * net)
 {
    cb_reset_calls++;
 }
 
 unsigned int cb_nmt_calls;
-void cb_nmt (void * arg, co_state_t state)
+void cb_nmt (co_net_t * net, co_state_t state)
 {
    cb_nmt_calls++;
 }
@@ -150,7 +150,7 @@ uint16_t cb_emcy_code;
 uint8_t cb_emcy_reg;
 uint8_t cb_emcy_msef[5];
 bool cb_emcy_result;
-bool cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5])
+bool cb_emcy (co_net_t * net, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5])
 {
    cb_emcy_calls++;
    cb_emcy_node = node;
@@ -162,7 +162,7 @@ bool cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef
 }
 
 unsigned int cb_sync_calls;
-void cb_sync (void * arg)
+void cb_sync (co_net_t * net)
 {
    cb_sync_calls++;
 }
@@ -170,7 +170,7 @@ void cb_sync (void * arg)
 unsigned int cb_notify_calls;
 uint16_t cb_notify_index;
 uint16_t cb_notify_subindex;
-void cb_notify (void * arg, uint16_t index, uint8_t subindex)
+void cb_notify (co_net_t * net, uint16_t index, uint8_t subindex)
 {
    cb_notify_calls++;
    cb_notify_index    = index;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -86,10 +86,10 @@ extern uint16_t mock_co_emcy_tx_code;
 void mock_co_emcy_tx (co_net_t * net, uint16_t code);
 
 extern unsigned int cb_reset_calls;
-void cb_reset (void * arg);
+void cb_reset (co_net_t * net);
 
 extern unsigned int cb_nmt_calls;
-void cb_nmt (void * arg, co_state_t state);
+void cb_nmt (co_net_t * net, co_state_t state);
 
 extern unsigned int cb_emcy_calls;
 extern uint8_t cb_emcy_node;
@@ -97,15 +97,15 @@ extern uint16_t cb_emcy_code;
 extern uint8_t cb_emcy_reg;
 extern uint8_t cb_emcy_msef[5];
 extern bool cb_emcy_result;
-bool cb_emcy (void * arg, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5]);
+bool cb_emcy (co_net_t * net, uint8_t node, uint16_t code, uint8_t reg, uint8_t msef[5]);
 
 extern unsigned int cb_sync_calls;
-void cb_sync (void * arg);
+void cb_sync (co_net_t * net);
 
 extern unsigned int cb_notify_calls;
 extern uint16_t cb_notify_index;
 extern uint16_t cb_notify_subindex;
-void cb_notify (void * arg, uint16_t index, uint8_t subindex);
+void cb_notify (co_net_t * net, uint16_t index, uint8_t subindex);
 
 void store_init (void);
 extern unsigned int store_open_calls;

--- a/util/slave/slave.c
+++ b/util/slave/slave.c
@@ -189,19 +189,19 @@ static int store_close (void * arg)
 }
 
 /* Called when NMT command Reset node is received */
-static void cb_reset (void * arg)
+static void cb_reset (co_net_t * net)
 {
    /* Optionally reset hardware */
 }
 
 /* Called when SYNC is received */
-static void cb_sync (void * arg)
+static void cb_sync (co_net_t * net)
 {
    input++;
 }
 
 /* Called when RPDO is received (if OD_NOTIFY is set) */
-static void cb_notify (void * arg, uint16_t index, uint8_t subindex)
+static void cb_notify (co_net_t * net, uint16_t index, uint8_t subindex)
 {
 }
 


### PR DESCRIPTION
It's currently impossible to reach the network handle from callbacks
that are called during co_init(), because even if the cb_arg is already
set up to point to a global object that is going to hold the network
handle, co_init() must return the handle before it can be stored there.

Add a function to retrieve the cb_arg opaque argument from the network
handle when needed. This is also useful to reach application specific
context in the object access functions.

Also add a function to get the node ID, which may differ from the default
because of LSS.