### PR TITLE
Add job types for local OD access

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -540,6 +540,40 @@ CO_EXPORT int co_error_clear (co_client_t * client, uint8_t mask);
  */
 CO_EXPORT int co_error_get (co_client_t * client, uint8_t * error);
 
+/**
+ * Read local dictionary object
+ *
+ * @param client        client handle
+ * @param index         index
+ * @param subindex      subindex
+ * @param value         result
+ *
+ * @return 0 on success, CO_STATUS error code otherwise
+ */
+CO_EXPORT int co_od_local_read (
+   co_client_t * client,
+   uint16_t index,
+   uint8_t subindex,
+   uint64_t * value);
+
+/**
+ * Write local directory object
+ *
+ * @param client        client handle
+ * @param index         index
+ * @param subindex      subindex
+ * @param value         value
+ * @param pdo_event     trigger PDOs that map this object
+ *
+ * @return 0 on success, CO_STATUS error code otherwise
+ */
+CO_EXPORT int co_od_local_write (
+   co_client_t * client,
+   uint16_t index,
+   uint8_t subindex,
+   uint64_t value,
+   bool pdo_event);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -33,6 +33,7 @@
 #include "co_pdo.h"
 #include "co_sync.h"
 #include "co_emcy.h"
+#include "co_od.h"
 #include "co_heartbeat.h"
 #include "co_node_guard.h"
 #include "co_lss.h"
@@ -142,6 +143,10 @@ void co_main (void * arg)
       case CO_JOB_ERROR_CLEAR:
       case CO_JOB_ERROR_GET:
          co_emcy_job (net, job);
+         break;
+      case CO_JOB_LOCAL_READ:
+      case CO_JOB_LOCAL_WRITE:
+         co_od_job (net, job);
          break;
       case CO_JOB_EXIT:
          running = false;
@@ -374,6 +379,56 @@ int co_error_get (co_client_t * client, uint8_t * error)
    os_sem_wait (client->sem, OS_WAIT_FOREVER);
 
    *error = job->emcy.value;
+
+   return job->result;
+}
+
+int co_od_local_read (
+   co_client_t * client,
+   uint16_t index,
+   uint8_t subindex,
+   uint64_t * value)
+{
+   co_net_t * net = client->net;
+   co_job_t * job = &client->job;
+
+   job->client       = client;
+   job->od.index     = index;
+   job->od.subindex  = subindex;
+   job->callback     = co_job_callback;
+   job->type         = CO_JOB_LOCAL_READ;
+
+   os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);
+   os_sem_wait (client->sem, OS_WAIT_FOREVER);
+
+   if (job->result == 0)
+   {
+      *value = job->od.value;
+   }
+
+   return job->result;
+}
+
+int co_od_local_write (
+   co_client_t * client,
+   uint16_t index,
+   uint8_t subindex,
+   uint64_t value,
+   bool pdo_event)
+{
+   co_net_t * net = client->net;
+   co_job_t * job = &client->job;
+
+   job->client       = client;
+   job->od.index     = index;
+   job->od.subindex  = subindex;
+   job->od.value     = value;
+   job->od.pdo_event = pdo_event;
+   job->callback     = co_job_callback;
+   job->type         = CO_JOB_LOCAL_WRITE;
+
+   os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);
+   os_sem_wait (client->sem, OS_WAIT_FOREVER);
 
    return job->result;
 }

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -103,6 +103,8 @@ typedef enum co_job_type
    CO_JOB_ERROR_SET,
    CO_JOB_ERROR_CLEAR,
    CO_JOB_ERROR_GET,
+   CO_JOB_LOCAL_READ,
+   CO_JOB_LOCAL_WRITE,
    CO_JOB_EXIT,
 } co_job_type_t;
 
@@ -139,6 +141,17 @@ typedef struct co_pdo_job
    uint8_t subindex;
 } co_pdo_job_t;
 
+typedef struct co_od_job
+{
+   uint16_t index;
+   uint8_t subindex;
+   uint64_t value;
+   struct
+   {
+      bool pdo_event : 1;
+   };
+} co_od_job_t;
+
 /** Generic job */
 typedef struct co_job
 {
@@ -148,6 +161,7 @@ typedef struct co_job
       co_sdo_job_t sdo;
       co_emcy_job_t emcy;
       co_pdo_job_t pdo;
+      co_od_job_t od;
    };
    uint32_t timestamp;
    struct co_client * client;

--- a/src/co_od.h
+++ b/src/co_od.h
@@ -271,6 +271,14 @@ uint32_t co_od_set_value (
    uint8_t subindex,
    uint64_t value);
 
+/**
+ * Perform local OD job
+ *
+ * @param net           network handle
+ * @param job           emcy job
+ */
+void co_od_job (co_net_t * net, co_job_t * job);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I needed to configure some PDOs dynamically based on application state. This was the only way I could do it, because the PDO configuration objects are otherwise only accessible via the bus. The same mechanism may be useful for other things.

It could also be useful to access large objects synchronized with the c-open thread, but for that the API functions should probably take void* and size instead. Something to consider.