### PR TITLE
Indicate hearbeat protocol state in node map

### DIFF
--- a/include/co_api.h
+++ b/include/co_api.h
@@ -360,8 +360,10 @@ CO_EXPORT co_client_t * co_client_init (co_net_t * net);
  * Get next active node ID.
  *
  * This function returns the next active node ID, i.e. a node that has
- * sent an NMT bootup message on the network. This function can be
- * used to iterate over active nodes.
+ * sent an NMT bootup message on the network and has not failed its
+ * error control protocol.
+
+ * This function can be used to iterate over active nodes.
  *
  * @code
  * node = co_node_next (net, 0);

--- a/src/co_heartbeat.c
+++ b/src/co_heartbeat.c
@@ -23,6 +23,7 @@
 #include "co_sdo.h"
 #include "co_emcy.h"
 #include "co_util.h"
+#include "co_bitmap.h"
 
 #include <string.h>
 
@@ -103,6 +104,8 @@ int co_heartbeat_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc)
 {
    int ix;
 
+   co_bitmap_set (net->nodes, node);
+
    for (ix = 0; ix < MAX_HEARTBEATS; ix++)
    {
       if (net->heartbeat[ix].node == node)
@@ -176,6 +179,7 @@ int co_heartbeat_timer (co_net_t * net, uint32_t now)
       {
          /* Expired */
          heartbeat->is_alive = false;
+         co_bitmap_clear (net->nodes, heartbeat->node);
          LOG_ERROR (
             CO_HEARTBEAT_LOG,
             "node %d heartbeat expired\n",

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -85,7 +85,6 @@ void co_handle_rx (co_net_t * net)
          }
          else if (function == CO_FUNCTION_NMT_ERR)
          {
-            co_bitmap_set (net->nodes, node);
             co_heartbeat_rx (net, node, data, dlc);
             co_node_guard_rx (net, id, data, dlc);
          }


### PR DESCRIPTION
The co_node_next function should not return true for nodes that have
failed the heartbeat protocol.