### PR TITLE
Switch to using ticks instead of time in osal

### DIFF
--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -17,7 +17,8 @@
 #define os_channel_send        mock_os_channel_send
 #define os_channel_get_state   mock_os_channel_get_state
 #define os_channel_bus_on      mock_os_channel_bus_on
-#define os_get_current_time_us mock_os_get_current_time_us
+#define os_tick_current        mock_os_tick_current
+#define os_tick_from_us        mock_os_tick_from_us
 #endif
 
 #include "co_emcy.h"
@@ -232,7 +233,7 @@ int co_emcy_tx (co_net_t * net, uint16_t code, uint16_t info, uint8_t msef[5])
    uint8_t msg[8] = {0};
    uint8_t * p    = msg;
    uint8_t reg;
-   uint32_t now;
+   os_tick_t now;
    bool error_behavior = false;
 
    if (net->number_of_errors < MAX_ERRORS)
@@ -263,7 +264,7 @@ int co_emcy_tx (co_net_t * net, uint16_t code, uint16_t info, uint8_t msef[5])
    }
 
    /* Send EMCY if inhibit time has expired */
-   now = os_get_current_time_us();
+   now = os_tick_current();
    if (co_is_expired (now, net->emcy.timestamp, 100 * net->emcy.inhibit))
    {
       LOG_ERROR (CO_EMCY_LOG, "emcy %x\n", code);
@@ -325,7 +326,7 @@ int co_emcy_rx (co_net_t * net, uint32_t id, uint8_t * msg, size_t dlc)
 void co_emcy_handle_can_state (co_net_t * net)
 {
    int status;
-   uint32_t now = os_get_current_time_us();;
+   os_tick_t now = os_tick_current();
    os_channel_state_t previous = net->emcy.state;
 
    /* Get current state */

--- a/src/co_heartbeat.c
+++ b/src/co_heartbeat.c
@@ -15,7 +15,8 @@
 
 #ifdef UNIT_TEST
 #define os_channel_send        mock_os_channel_send
-#define os_get_current_time_us mock_os_get_current_time_us
+#define os_tick_current        mock_os_tick_current
+#define os_tick_from_us        mock_os_tick_from_us
 #define co_emcy_tx             mock_co_emcy_tx
 #endif
 
@@ -112,7 +113,7 @@ int co_heartbeat_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc)
       {
          co_heartbeat_t * heartbeat = &net->heartbeat[ix];
 
-         heartbeat->timestamp = os_get_current_time_us();
+         heartbeat->timestamp = os_tick_current();
          heartbeat->is_alive  = true;
          LOG_DEBUG (CO_HEARTBEAT_LOG, "node %d got heartbeat\n", heartbeat->node);
       }
@@ -121,7 +122,7 @@ int co_heartbeat_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc)
    return 0;
 }
 
-int co_heartbeat_timer (co_net_t * net, uint32_t now)
+int co_heartbeat_timer (co_net_t * net, os_tick_t now)
 {
    unsigned int ix;
    bool heartbeat_error = false;

--- a/src/co_heartbeat.h
+++ b/src/co_heartbeat.h
@@ -56,7 +56,7 @@ int co_heartbeat_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc);
  *
  * @return 0 on success, -1 on failure
  */
-int co_heartbeat_timer (co_net_t * net, uint32_t now);
+int co_heartbeat_timer (co_net_t * net, os_tick_t now);
 
 #ifdef __cplusplus
 }

--- a/src/co_main.c
+++ b/src/co_main.c
@@ -98,7 +98,7 @@ void co_handle_rx (co_net_t * net)
 
 void co_handle_periodic (co_net_t * net)
 {
-   uint32_t now = os_get_current_time_us();
+   os_tick_t now = os_tick_current();
 
    co_sdo_server_timer (net, now);
    co_sdo_client_timer (net, now);
@@ -278,7 +278,7 @@ int co_sdo_read (
    job->sdo.data     = data;
    job->sdo.remain   = size;
    job->callback     = co_job_callback;
-   job->timestamp    = os_get_current_time_us();
+   job->timestamp    = os_tick_current();
    job->type         = CO_JOB_SDO_READ;
 
    os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);
@@ -307,7 +307,7 @@ int co_sdo_write (
    job->sdo.data     = (uint8_t *)data;
    job->sdo.remain   = size;
    job->callback     = co_job_callback;
-   job->timestamp    = os_get_current_time_us();
+   job->timestamp    = os_tick_current();
    job->type         = CO_JOB_SDO_WRITE;
 
    os_mbox_post (net->mbox, job, OS_WAIT_FOREVER);

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -74,7 +74,7 @@ typedef struct co_pdo
    uint8_t sync_counter;
    uint16_t inhibit_time;
    uint16_t event_timer;
-   uint32_t timestamp;
+   os_tick_t timestamp;
    uint64_t frame;
    size_t bitlength;
    uint8_t number_of_mappings;
@@ -149,7 +149,7 @@ typedef struct co_job
       co_emcy_job_t emcy;
       co_pdo_job_t pdo;
    };
-   uint32_t timestamp;
+   os_tick_t timestamp;
    struct co_client * client;
    void (*callback) (struct co_job * job);
    int result;
@@ -169,7 +169,7 @@ typedef struct co_heartbeat
    uint8_t node;
    bool is_alive;
    uint16_t time;
-   uint32_t timestamp;
+   os_tick_t timestamp;
 } co_heartbeat_t;
 
 /** Node guarding state */
@@ -179,7 +179,7 @@ typedef struct co_node_guard
    uint16_t guard_time;
    uint8_t life_time_factor;
    uint8_t toggle;
-   uint32_t timestamp;
+   os_tick_t timestamp;
 } co_node_guard_t;
 
 /** LSS states */
@@ -206,14 +206,14 @@ typedef struct co_sync
    uint8_t counter;
    uint8_t overflow;
    uint32_t period;
-   uint32_t timestamp;
+   os_tick_t timestamp;
 } co_sync_t;
 
 /** EMCY state */
 typedef struct co_emcy
 {
    uint32_t cobid;                   /**< EMCY COB ID */
-   uint32_t timestamp;               /**< Timestamp of last EMCY */
+   os_tick_t timestamp;               /**< Timestamp of last EMCY */
    uint32_t bus_off_timestamp;       /**< Timestamp of bus-off event */
    uint16_t inhibit;                 /**< Inhibit time [100 us] */
    uint8_t error;                    /**< Error register */
@@ -238,9 +238,9 @@ struct co_net
    co_emcy_t emcy;              /**< EMCY state */
    co_sync_t sync;              /**< SYNC state */
    co_state_t state;            /**< NMT state */
-   uint32_t hb_timestamp;       /**< Heartbeat producer timestamp */
+   os_tick_t hb_timestamp;       /**< Heartbeat producer timestamp */
    uint32_t hb_time;            /**< Heartbeat producer time */
-   uint32_t sync_timestamp;     /**< Timestamp of last SYNC */
+   os_tick_t sync_timestamp;     /**< Timestamp of last SYNC */
    uint32_t sync_window;        /**< Synchronous window length */
    uint32_t restart_ms;         /**< Delay before attempting to recover from bus-off */
    co_pdo_t pdo_tx[MAX_TX_PDO]; /**< TPDOs */

--- a/src/co_node_guard.c
+++ b/src/co_node_guard.c
@@ -16,7 +16,8 @@
 #ifdef UNIT_TEST
 #define os_channel_send        mock_os_channel_send
 #define os_channel_receive     mock_os_channel_receive
-#define os_get_current_time_us mock_os_get_current_time_us
+#define os_tick_current        mock_os_tick_current
+#define os_tick_from_us        mock_os_tick_from_us
 #endif
 
 #include "co_node_guard.h"
@@ -84,7 +85,7 @@ int co_node_guard_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc)
       return -1;
 
    net->node_guard.is_alive  = true;
-   net->node_guard.timestamp = os_get_current_time_us();
+   net->node_guard.timestamp = os_tick_current();
 
    /* Heartbeat producer (heartbeat is prioritised over node guarding)*/
    if (net->hb_time == 0)
@@ -113,7 +114,7 @@ int co_node_guard_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc)
    return 0;
 }
 
-int co_node_guard_timer (co_net_t * net, uint32_t now)
+int co_node_guard_timer (co_net_t * net, os_tick_t now)
 {
    uint32_t guard_factor =
       (net->node_guard.guard_time * net->node_guard.life_time_factor);

--- a/src/co_node_guard.h
+++ b/src/co_node_guard.h
@@ -55,7 +55,7 @@ int co_node_guard_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc);
  *
  * @return 0 on success, -1 on failure
  */
-int co_node_guard_timer (co_net_t * net, uint32_t now);
+int co_node_guard_timer (co_net_t * net, os_tick_t now);
 
 #ifdef __cplusplus
 }

--- a/src/co_pdo.h
+++ b/src/co_pdo.h
@@ -103,7 +103,7 @@ void co_pdo_rx (co_net_t * net, uint32_t id, void * msg, size_t dlc);
  *
  * @return 0 on success, -1 on failure
  */
-int co_pdo_timer (co_net_t * net, uint32_t now);
+int co_pdo_timer (co_net_t * net, os_tick_t now);
 
 /**
  * PDO trigger

--- a/src/co_sdo.h
+++ b/src/co_sdo.h
@@ -125,7 +125,7 @@ int co_sdo_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc);
  *
  * @return 0 on success, -1 on failure
  */
-int co_sdo_server_timer (co_net_t * net, uint32_t now);
+int co_sdo_server_timer (co_net_t * net, os_tick_t now);
 
 /**
  * SDO client timer
@@ -139,7 +139,7 @@ int co_sdo_server_timer (co_net_t * net, uint32_t now);
  *
  * @return 0 on success, -1 on failure
  */
-int co_sdo_client_timer (co_net_t * net, uint32_t now);
+int co_sdo_client_timer (co_net_t * net, os_tick_t now);
 
 /**
  * Issue SDO request

--- a/src/co_sdo_client.c
+++ b/src/co_sdo_client.c
@@ -18,6 +18,7 @@
 #define os_channel_receive mock_os_channel_receive
 #define co_obj_find        mock_co_obj_find
 #define co_entry_find      mock_co_entry_find
+#define os_tick_from_us    mock_os_tick_from_us
 #endif
 
 #include "co_sdo.h"
@@ -314,7 +315,7 @@ void co_sdo_issue (co_net_t * net, co_job_t * job)
    os_channel_send (net->channel, 0x600 + job->sdo.node, msg, sizeof (msg));
 }
 
-int co_sdo_client_timer (co_net_t * net, uint32_t now)
+int co_sdo_client_timer (co_net_t * net, os_tick_t now)
 {
    co_job_t * job = net->job_client;
 

--- a/src/co_sdo_server.c
+++ b/src/co_sdo_server.c
@@ -14,7 +14,8 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
-#define os_get_current_time_us mock_os_get_current_time_us
+#define os_tick_current    mock_os_tick_current
+#define os_tick_from_us    mock_os_tick_from_us
 #define os_channel_send    mock_os_channel_send
 #define os_channel_receive mock_os_channel_receive
 #define co_obj_find        mock_co_obj_find
@@ -128,7 +129,7 @@ static int co_sdo_rx_upload_init_req (
    job->type         = CO_JOB_SDO_UPLOAD;
    job->sdo.index    = co_fetch_uint16 (&data[1]);
    job->sdo.subindex = data[3];
-   job->timestamp    = os_get_current_time_us();
+   job->timestamp    = os_tick_current();
 
    /* Find requested object */
    obj = co_obj_find (net, job->sdo.index);
@@ -281,7 +282,7 @@ static int co_sdo_rx_upload_seg_req (
 
       job->sdo.data += size;
       job->sdo.remain -= size;
-      job->timestamp = os_get_current_time_us();
+      job->timestamp = os_tick_current();
    }
 
    os_channel_send (net->channel, 0x580 + net->node, msg, sizeof (msg));
@@ -305,7 +306,7 @@ static int co_sdo_rx_download_init_req (
    job->type         = CO_JOB_SDO_DOWNLOAD;
    job->sdo.index    = co_fetch_uint16 (&data[1]);
    job->sdo.subindex = data[3];
-   job->timestamp    = os_get_current_time_us();
+   job->timestamp    = os_tick_current();
 
    /* Find requested object */
    obj = co_obj_find (net, job->sdo.index);
@@ -458,7 +459,7 @@ static int co_sdo_rx_download_seg_req (
 
    job->sdo.data += size;
    job->sdo.remain -= size;
-   job->timestamp = os_get_current_time_us();
+   job->timestamp = os_tick_current();
 
    if (data[0] & CO_SDO_C)
    {
@@ -572,7 +573,7 @@ int co_sdo_rx (co_net_t * net, uint8_t node, void * msg, size_t dlc)
    }
 }
 
-int co_sdo_server_timer (co_net_t * net, uint32_t now)
+int co_sdo_server_timer (co_net_t * net, os_tick_t now)
 {
    co_job_t * job = &net->job_sdo_server;
 

--- a/src/co_sync.c
+++ b/src/co_sync.c
@@ -15,6 +15,7 @@
 
 #ifdef UNIT_TEST
 #define os_channel_send mock_os_channel_send
+#define os_tick_from_us mock_os_tick_from_us
 #endif
 
 #include "co_sync.h"
@@ -45,7 +46,7 @@ uint32_t co_od1005_fn (
       if ((*value & sync->cobid & BIT (30)) == 0)
       {
          sync->cobid     = *value;
-         sync->timestamp = os_get_current_time_us();
+         sync->timestamp = os_tick_current();
          return 0;
       }
 
@@ -122,7 +123,7 @@ uint32_t co_od1019_fn (
          return CO_SDO_ABORT_VALUE;
 
       sync->overflow  = *value;
-      sync->timestamp = os_get_current_time_us();
+      sync->timestamp = os_tick_current();
       return 0;
 
    case OD_EVENT_RESTORE:
@@ -135,7 +136,7 @@ uint32_t co_od1019_fn (
    return 0;
 }
 
-int co_sync_timer (co_net_t * net, uint32_t now)
+int co_sync_timer (co_net_t * net, os_tick_t now)
 {
    co_sync_t * sync = &net->sync;
 

--- a/src/co_sync.h
+++ b/src/co_sync.h
@@ -39,7 +39,7 @@ extern "C" {
  *
  * @return 0 on success, -1 on failure
  */
-int co_sync_timer (co_net_t * net, uint32_t now);
+int co_sync_timer (co_net_t * net, os_tick_t now);
 
 #ifdef __cplusplus
 }

--- a/src/co_util.h
+++ b/src/co_util.h
@@ -25,10 +25,10 @@ extern "C" {
 
 #include "osal.h"
 
-static inline int co_is_expired (uint32_t now, uint32_t timestamp, uint32_t timeout)
+static inline int co_is_expired (os_tick_t now, os_tick_t timestamp, uint32_t timeout)
 {
-   uint32_t delta = now - timestamp;
-   return delta >= timeout;
+   os_tick_t delta = now - timestamp;
+   return delta >= os_tick_from_us(timeout);
 }
 
 static inline bool co_validate_cob_id (uint32_t id)

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -18,10 +18,15 @@
 #include <gtest/gtest.h>
 #include <string.h>
 
-uint32_t mock_os_get_current_time_us_result = 0;
-uint32_t mock_os_get_current_time_us (void)
+os_tick_t mock_os_tick_current_result = 0;
+os_tick_t mock_os_tick_current (void)
 {
-   return mock_os_get_current_time_us_result;
+   return mock_os_tick_current_result;
+}
+
+os_tick_t mock_os_tick_from_us (uint32_t us)
+{
+   return us;
 }
 
 unsigned int mock_os_channel_send_calls = 0;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -22,11 +22,14 @@ extern "C" {
 
 #include <stdint.h>
 
+#include "osal.h"
 #include "co_api.h"
 #include "co_main.h"
 
-extern uint32_t mock_os_get_current_time_us_result;
-uint32_t mock_os_get_current_time_us (void);
+extern os_tick_t mock_os_tick_current_result;
+os_tick_t mock_os_tick_current (void);
+
+os_tick_t mock_os_tick_from_us (uint32_t us);
 
 extern unsigned int mock_os_channel_send_calls;
 extern uint32_t mock_os_channel_send_id;

--- a/test/test_emcy.cpp
+++ b/test/test_emcy.cpp
@@ -410,7 +410,7 @@ TEST_F (EmcyTest, EmcyBusOffRecovery)
    co_emcy_handle_can_state (&net);
 
    // Should attempt bus off recovery after timeout
-   mock_os_get_current_time_us_result = 101 * 1000;
+   mock_os_tick_current_result = 101 * 1000;
    co_emcy_handle_can_state (&net);
    EXPECT_EQ (1u, mock_os_channel_bus_on_calls);
 }
@@ -420,17 +420,17 @@ TEST_F (EmcyTest, EmcyInhibit)
    net.emcy.inhibit = 10; // 10 * 100 us
 
    // Should send EMCY
-   mock_os_get_current_time_us_result = 10 * 100;
+   mock_os_tick_current_result = 10 * 100;
    co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (1u, mock_os_channel_send_calls);
 
    // Inhibit time active, should not send EMCY
-   mock_os_get_current_time_us_result = 15 * 100;
+   mock_os_tick_current_result = 15 * 100;
    co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (1u, mock_os_channel_send_calls);
 
    // Inhibit time expired, should send EMCY
-   mock_os_get_current_time_us_result = 20 * 100;
+   mock_os_tick_current_result = 20 * 100;
    co_emcy_tx (&net, 0x8130, 0x1234, msef);
    EXPECT_EQ (2u, mock_os_channel_send_calls);
 }

--- a/test/test_heartbeat.cpp
+++ b/test/test_heartbeat.cpp
@@ -105,7 +105,7 @@ TEST_F (HeartbeatTest, HeartbeatConsumer)
    net.heartbeat[0].time = 1000;
 
    // Receive heartbeat within timer window
-   mock_os_get_current_time_us_result = 500 * 1000;
+   mock_os_tick_current_result = 500 * 1000;
    co_heartbeat_rx (&net, 1, &heartbeat, 1);
    EXPECT_TRUE (net.heartbeat[0].is_alive);
 
@@ -120,7 +120,7 @@ TEST_F (HeartbeatTest, HeartbeatConsumer)
    EXPECT_EQ (1u, mock_co_emcy_tx_calls);
 
    // Receive heartbeat, should set is_alive
-   mock_os_get_current_time_us_result = 2000 * 1000;
+   mock_os_tick_current_result = 2000 * 1000;
    co_heartbeat_rx (&net, 1, &heartbeat, 1);
    EXPECT_TRUE (net.heartbeat[0].is_alive);
 }
@@ -133,7 +133,7 @@ TEST_F (HeartbeatTest, ShouldMaintainNodeMap)
    net.heartbeat[0].time = 1000;
 
    // Receive heartbeat within timer window, should set active node ID
-   mock_os_get_current_time_us_result = 500 * 1000;
+   mock_os_tick_current_result = 500 * 1000;
    co_heartbeat_rx (&net, 1, &heartbeat, 1);
    EXPECT_TRUE (co_bitmap_get (net.nodes, 1));
 

--- a/test/test_node_guard.cpp
+++ b/test/test_node_guard.cpp
@@ -142,7 +142,7 @@ TEST_F (NodeGuardTest, Expire)
    net.node_guard.life_time_factor = 2;
 
    // Receive node guard request, reset timestamp
-   mock_os_get_current_time_us_result = 10 * 1000;
+   mock_os_tick_current_result = 10 * 1000;
    mock_os_channel_send_id            = 0;
    co_node_guard_rx (&net, NODE_GUARD_BASE | 1, &rtr, 1);
    EXPECT_TRUE (CanMatch (0x701, &expected[0], 1));
@@ -150,7 +150,7 @@ TEST_F (NodeGuardTest, Expire)
    EXPECT_EQ (STATE_OP, net.state);
 
    // Receive node guard request, reset timestamp
-   mock_os_get_current_time_us_result = 20 * 1000;
+   mock_os_tick_current_result = 20 * 1000;
    mock_os_channel_send_id            = 0;
    co_node_guard_rx (&net, NODE_GUARD_BASE | 1, &rtr, 1);
    EXPECT_TRUE (CanMatch (0x701, &expected[1], 1));
@@ -179,7 +179,7 @@ TEST_F (NodeGuardTest, Expire)
    EXPECT_EQ (STATE_PREOP, net.state);
 
    // Receive node guard request, reset timestamp
-   mock_os_get_current_time_us_result = 300 * 1000;
+   mock_os_tick_current_result = 300 * 1000;
    mock_os_channel_send_id            = 0;
    co_node_guard_rx (&net, NODE_GUARD_BASE | 1, &rtr, 1);
    EXPECT_TRUE (CanMatch (0x701, &expected[2], 1));
@@ -187,7 +187,7 @@ TEST_F (NodeGuardTest, Expire)
    EXPECT_EQ (STATE_PREOP, net.state);
 
    // Receive node guard request, reset timestamp
-   mock_os_get_current_time_us_result = 350 * 1000;
+   mock_os_tick_current_result = 350 * 1000;
    mock_os_channel_send_id            = 0;
    co_node_guard_rx (&net, NODE_GUARD_BASE | 1, &rtr, 1);
    EXPECT_TRUE (CanMatch (0x701, &expected[3], 1));

--- a/test/test_pdo.cpp
+++ b/test/test_pdo.cpp
@@ -615,22 +615,22 @@ TEST_F (PdoTest, RxSyncWindow)
    co_pdo_sync (&net, &counter, sizeof (counter));
 
    // In sync window, should buffer value
-   mock_os_get_current_time_us_result = 50;
+   mock_os_tick_current_result = 50;
    co_pdo_rx (&net, 0x201, pdo[0], sizeof (pdo[0]));
    EXPECT_EQ (0u, value7000);
 
    // Sync, should deliver value
-   mock_os_get_current_time_us_result = 1000;
+   mock_os_tick_current_result = 1000;
    co_pdo_sync (&net, &counter, sizeof (counter));
    EXPECT_EQ (0x44332211u, value7000);
 
    // Outside sync window, should not buffer value
-   mock_os_get_current_time_us_result = 150;
+   mock_os_tick_current_result = 150;
    co_pdo_rx (&net, 0x201, pdo[1], sizeof (pdo[1]));
    EXPECT_EQ (0x44332211u, value7000);
 
    // Sync, should not deliver value
-   mock_os_get_current_time_us_result = 2000;
+   mock_os_tick_current_result = 2000;
    co_pdo_sync (&net, &counter, sizeof (counter));
    EXPECT_EQ (0x44332211u, value7000);
 }
@@ -680,13 +680,13 @@ TEST_F (PdoTest, TxEventTimer)
    net.pdo_tx[0].event_timer       = 100;
 
    // Timer has not expired
-   mock_os_get_current_time_us_result = 50 * 1000;
-   co_pdo_timer (&net, mock_os_get_current_time_us_result);
+   mock_os_tick_current_result = 50 * 1000;
+   co_pdo_timer (&net, mock_os_tick_current_result);
    EXPECT_EQ (0x0u, mock_os_channel_send_calls);
 
    // Timer has expired
-   mock_os_get_current_time_us_result = 150 * 1000;
-   co_pdo_timer (&net, mock_os_get_current_time_us_result);
+   mock_os_tick_current_result = 150 * 1000;
+   co_pdo_timer (&net, mock_os_tick_current_result);
    EXPECT_EQ (0x1u, mock_os_channel_send_calls);
    EXPECT_EQ (0x181u, mock_os_channel_send_id);
 }
@@ -699,12 +699,12 @@ TEST_F (PdoTest, TxInhibitTime)
    net.pdo_tx[0].inhibit_time      = 100;
 
    // Timer has not expired
-   mock_os_get_current_time_us_result = 50 * 100;
+   mock_os_tick_current_result = 50 * 100;
    co_pdo_trigger (&net);
    EXPECT_EQ (0x0u, mock_os_channel_send_calls);
 
    // Timer has expired
-   mock_os_get_current_time_us_result = 150 * 100;
+   mock_os_tick_current_result = 150 * 100;
    co_pdo_trigger (&net);
    EXPECT_EQ (0x1u, mock_os_channel_send_calls);
    EXPECT_EQ (0x181u, mock_os_channel_send_id);

--- a/test/test_sdo_server.cpp
+++ b/test/test_sdo_server.cpp
@@ -168,7 +168,7 @@ TEST_F (SdoServerTest, SegmentedTimeout)
       {0x40, 0x08, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00},
       {0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
    };
-   uint32_t now;
+   os_tick_t now;
 
    mock_co_obj_find_result   = find_obj (0x1008);
    mock_co_entry_find_result = find_entry (mock_co_obj_find_result, 0);
@@ -180,7 +180,7 @@ TEST_F (SdoServerTest, SegmentedTimeout)
    co_sdo_server_timer (&net, now);
    EXPECT_TRUE (CanMatch (0x581, expected[0], 8));
 
-   mock_os_get_current_time_us_result = now;
+   mock_os_tick_current_result = now;
    co_sdo_rx (&net, 1, command[1], 8);
 
    // Should not time out

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -62,7 +62,7 @@ class TestBase : public ::testing::Test
       cb_sync_calls   = 0;
       cb_notify_calls = 0;
 
-      mock_os_get_current_time_us_result = 0;
+      mock_os_tick_current_result = 0;
       mock_os_channel_send_calls         = 0;
       mock_os_channel_send_id            = 0;
       mock_os_channel_receive_calls      = 0;


### PR DESCRIPTION
Switch to using ticks from OSAL instead of calculating in time. The time function in OSAL does not always wrap on uint32_t boundaries, which causes problems with execution.

This depends on: https://github.com/rtlabs-com/osal/pull/19