### PR TITLE
Add RPDO deadline monitoring

### DIFF
--- a/src/co_emcy.c
+++ b/src/co_emcy.c
@@ -384,7 +384,7 @@ void co_emcy_handle_can_state (co_net_t * net)
    if (
       !net->emcy.state.overrun && !net->emcy.state.error_passive &&
       !net->emcy.state.bus_off && !net->emcy.node_guard_error &&
-      !net->emcy.heartbeat_error)
+      !net->emcy.heartbeat_error && !net->emcy.rpdo_timeout)
    {
       co_emcy_error_register_clear (net, CO_ERR_COMMUNICATION);
    }

--- a/src/co_main.h
+++ b/src/co_main.h
@@ -82,6 +82,8 @@ typedef struct co_pdo
    {
       bool queued : 1;
       bool sync_wait : 1;
+      bool rpdo_monitoring : 1;
+      bool rpdo_timeout : 1;
    };
    uint32_t mappings[MAX_PDO_ENTRIES];
    const co_obj_t * objs[MAX_PDO_ENTRIES];
@@ -220,6 +222,7 @@ typedef struct co_emcy
    os_channel_state_t state;         /**< CAN state */
    bool node_guard_error;            /**< Node guard error */
    bool heartbeat_error;             /**< Heartbeat error */
+   bool rpdo_timeout;                /**< RPDO timeout */
    uint32_t cobids[MAX_EMCY_COBIDS]; /**< EMCY consumer object */
 } co_emcy_t;
 


### PR DESCRIPTION
As described in CiA 301, Object 1400h to 15FFh: RPDO communication parameter, Subindex 05h.

The indication to the application is done via the EMCY callback. The EMCY transmission is not described, but since there is an EMCY code defined for RPDO timeout, it's assumed to be meant for this purpose.
